### PR TITLE
add verification and dynamic player score saveing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,8 @@ ENV POSTGRES_URL "postgresql://localhost:5432/postgres"
 ENV POSTGRES_USER "postgres"
 ENV POSTGRES_PASSWORD "postgres"
 ENV OVERWORLD_URL "http://overworld-backend/overworld/api/v1"
-ENTRYPOINT /usr/local/openjdk-17/bin/java -jar /usr/local/lib/finitequiz-backend.jar --spring.datasource.url=jdbc:${POSTGRES_URL} --server.port=80 --spring.datasource.username=${POSTGRES_USER} --spring.datasource.password=${POSTGRES_PASSWORD} --overworld.url=${OVERWORLD_URL}
+ENV KEYCLOAK_ISSUER "http://keycloak/keycloak/realms/Gamify-IT"
+ENTRYPOINT /usr/local/openjdk-17/bin/java -jar /usr/local/lib/finitequiz-backend.jar \
+    --spring.datasource.url=jdbc:${POSTGRES_URL} --server.port=80 \
+    --spring.datasource.username=${POSTGRES_USER} --spring.datasource.password=${POSTGRES_PASSWORD} \
+    --overworld.url=${OVERWORLD_URL} --keycloak.issuer=${KEYCLOAK_ISSUER}

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -99,7 +99,7 @@ services:
 
   finitequiz:
     container_name: finitequiz
-    image: ghcr.io/gamify-it/finitequiz:main
+    image: ghcr.io/gamify-it/finitequiz:latest
     restart: always
     pull_policy: always
     expose:

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -99,7 +99,7 @@ services:
 
   finitequiz:
     container_name: finitequiz
-    image: ghcr.io/gamify-it/finitequiz:latest
+    image: ghcr.io/gamify-it/finitequiz:main
     restart: always
     pull_policy: always
     expose:

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,19 @@
             <artifactId>java-jwt</artifactId>
             <version>3.19.2</version>
         </dependency>
+        <dependency>
+            <groupId>de.uni-stuttgart.gamify-it</groupId>
+            <artifactId>authentification-validator</artifactId>
+            <version>v0.0.1</version>
+        </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <id>sqa-artifactory</id>
+            <name>SQA Artifactory-releases</name>
+            <url>https://rss-artifactory.ddnss.org/artifactory/libs-release</url>
+        </repository>
+    </repositories>
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/src/main/java/de/unistuttgart/finitequizbackend/controller/ConfigController.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/controller/ConfigController.java
@@ -6,11 +6,16 @@ import de.unistuttgart.finitequizbackend.data.mapper.ConfigurationMapper;
 import de.unistuttgart.finitequizbackend.data.mapper.QuestionMapper;
 import de.unistuttgart.finitequizbackend.repositories.ConfigurationRepository;
 import de.unistuttgart.finitequizbackend.service.ConfigService;
+
+import java.net.MalformedURLException;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+
+import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,36 +36,51 @@ public class ConfigController {
   @Autowired
   ConfigurationMapper configurationMapper;
 
+  @Value("${keycloak.issuer}")
+  private String keycloakIssuer;
+
+  private JWTValidatorService jwtValidatorService;
+  @Autowired
+  private void setJWTValidatorService() throws MalformedURLException {
+    jwtValidatorService = new JWTValidatorService(keycloakIssuer);
+  }
+
   @GetMapping("")
-  public List<ConfigurationDTO> getConfigurations() {
+  public List<ConfigurationDTO> getConfigurations(@CookieValue("access_token") final String accessToken) {
+    jwtValidatorService.validate(accessToken);
     log.debug("get all configurations");
     return configurationMapper.configurationsToConfigurationDTOs(configurationRepository.findAll());
   }
 
   @GetMapping("/{id}")
-  public ConfigurationDTO getConfiguration(@PathVariable final UUID id) {
+  public ConfigurationDTO getConfiguration(@CookieValue("access_token") final String accessToken, @PathVariable final UUID id) {
+    jwtValidatorService.validate(accessToken);
     log.debug("get configuration {}", id);
     return configurationMapper.configurationToConfigurationDTO(configService.getConfiguration(id));
   }
 
   @PostMapping("")
   @ResponseStatus(HttpStatus.CREATED)
-  public ConfigurationDTO createConfiguration(@RequestBody final ConfigurationDTO configurationDTO) {
+  public ConfigurationDTO createConfiguration(    @CookieValue("access_token") final String accessToken, @RequestBody final ConfigurationDTO configurationDTO) {
+    jwtValidatorService.checkLecturer(accessToken);
     log.debug("create configuration {}", configurationDTO);
     return configService.saveConfiguration(configurationDTO);
   }
 
   @PutMapping("/{id}")
   public ConfigurationDTO updateConfiguration(
+    @CookieValue("access_token") final String accessToken,
     @PathVariable final UUID id,
     @RequestBody final ConfigurationDTO configurationDTO
   ) {
+    jwtValidatorService.checkLecturer(accessToken);
     log.debug("update configuration {} with {}", id, configurationDTO);
     return configService.updateConfiguration(id, configurationDTO);
   }
 
   @DeleteMapping("/{id}")
-  public ConfigurationDTO deleteConfiguration(@PathVariable final UUID id) {
+  public ConfigurationDTO deleteConfiguration(@CookieValue("access_token") final String accessToken, @PathVariable final UUID id) {
+    jwtValidatorService.checkLecturer(accessToken);
     log.debug("delete configuration {}", id);
     return configService.deleteConfiguration(id);
   }
@@ -68,31 +88,38 @@ public class ConfigController {
   @PostMapping("/{id}/questions")
   @ResponseStatus(HttpStatus.CREATED)
   public QuestionDTO addQuestionToConfiguration(
+    @CookieValue("access_token") final String accessToken,
     @PathVariable final UUID id,
     @RequestBody final QuestionDTO questionDTO
   ) {
+    jwtValidatorService.checkLecturer(accessToken);
     log.debug("add question {} to configuration {}", questionDTO, id);
     return configService.addQuestionToConfiguration(id, questionDTO);
   }
 
   @DeleteMapping("/{id}/questions/{questionId}")
-  public QuestionDTO removeQuestionFromConfiguration(@PathVariable final UUID id, @PathVariable final UUID questionId) {
+  public QuestionDTO removeQuestionFromConfiguration(@CookieValue("access_token") final String accessToken,@PathVariable final UUID id, @PathVariable final UUID questionId) {
+    jwtValidatorService.checkLecturer(accessToken);
     log.debug("remove question {} from configuration {}", questionId, id);
     return configService.removeQuestionFromConfiguration(id, questionId);
   }
 
   @PutMapping("/{id}/questions/{questionId}")
   public QuestionDTO updateQuestionFromConfiguration(
+    @CookieValue("access_token") final String accessToken,
     @PathVariable final UUID id,
     @PathVariable final UUID questionId,
     @RequestBody final QuestionDTO questionDTO
   ) {
+    jwtValidatorService.checkLecturer(accessToken);
     log.debug("update question {} with {} for configuration {}", questionId, questionDTO, id);
     return configService.updateQuestionFromConfiguration(id, questionId, questionDTO);
   }
 
   @GetMapping("/{id}/questions")
-  public Set<QuestionDTO> getQuestions(@PathVariable final UUID id) {
+  public Set<QuestionDTO> getQuestions(@CookieValue("access_token") final String accessToken,
+                                       @PathVariable final UUID id) {
+    jwtValidatorService.validate(accessToken);
     log.debug("get configuration {}", id);
     return configurationMapper.configurationToConfigurationDTO(configService.getConfiguration(id)).getQuestions();
   }

--- a/src/main/java/de/unistuttgart/finitequizbackend/controller/GameResultController.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/controller/GameResultController.java
@@ -2,10 +2,14 @@ package de.unistuttgart.finitequizbackend.controller;
 
 import de.unistuttgart.finitequizbackend.data.GameResultDTO;
 import de.unistuttgart.finitequizbackend.service.GameResultService;
+import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import java.net.MalformedURLException;
 
 @RestController
 @RequestMapping("/results")
@@ -15,11 +19,21 @@ public class GameResultController {
   @Autowired
   GameResultService gameResultService;
 
+  @Value("${keycloak.issuer}")
+  private String keycloakIssuer;
+
+  private JWTValidatorService jwtValidatorService;
+  @Autowired
+  private void setJWTValidatorService() throws MalformedURLException {
+    jwtValidatorService = new JWTValidatorService(keycloakIssuer);
+  }
+
   @PostMapping("")
   @ResponseStatus(HttpStatus.CREATED)
-  public GameResultDTO saveGameResult(@RequestBody final GameResultDTO gameResultDTO) {
-    log.debug("save game result");
-    gameResultService.saveGameResult(gameResultDTO);
+  public GameResultDTO saveGameResult(@CookieValue("access_token") final String accessToken, @RequestBody final GameResultDTO gameResultDTO) {
+    final String userId = jwtValidatorService.validate(accessToken).getSubject();
+    log.info("save game result for userId {}: {}", userId, gameResultDTO);
+    gameResultService.saveGameResult(gameResultDTO, userId);
     return gameResultDTO;
   }
 }

--- a/src/main/java/de/unistuttgart/finitequizbackend/service/GameResultService.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/service/GameResultService.java
@@ -61,12 +61,13 @@ public class GameResultService {
    *
    * @param gameResultDTO extern gameResultDTO
    */
-  public void saveGameResult(GameResultDTO gameResultDTO) {
+  public void saveGameResult(final GameResultDTO gameResultDTO, final String userId) {
+    final int resultScore = calculateResultScore(gameResultDTO.getCorrectAnsweredQuestions().size(), gameResultDTO.getQuestionCount());
     OverworldResultDTO resultDTO = new OverworldResultDTO(
             "FINITEQUIZ",
             gameResultDTO.getConfigurationAsUUID(),
-            50,
-            "1"
+            resultScore,
+            userId
     );
     try {
       resultClient.submit(resultDTO);
@@ -78,7 +79,7 @@ public class GameResultService {
               correctQuestions,
               wrongQuestions,
               gameResultDTO.getConfigurationAsUUID(),
-              "playerId"
+              userId
       );
       gameResultRepository.save(result);
     } catch (FeignException.BadGateway badGateway) {
@@ -92,5 +93,8 @@ public class GameResultService {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND,
               warning);
     }
+  }
+  private int calculateResultScore(final int correctAnswers, final int numberOfQuestions) {
+    return (int) ((100.0 * correctAnswers) / numberOfQuestions);
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,4 +16,4 @@ spring.jpa.generate-ddl=true
 server.error.include-message=always
 
 overworld.url = http://localhost/overworld/api/v1
-
+keycloak.issuer=http://localhost/keycloak/realms/Gamify-IT


### PR DESCRIPTION
Part of Gamify-IT/issues#251

To test run the docker compose and try to access the backend.

Without login you should receive a `500` if cookie is not set. If the token in the cookie is invalid you should get a `401`

Also if you access lecturer-only endpoints (for example create a minigame) as student you receive a `401`.

Keycloak lecturer user is: `lecturer` `lecturer`


The tests are too complicated to be done in this task. They will follow soon.