### PR TITLE
Add a statistic endpoint

### DIFF
--- a/src/main/java/de/unistuttgart/finitequizbackend/controller/StatisticController.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/controller/StatisticController.java
@@ -49,8 +49,7 @@ public class StatisticController {
         @PathVariable final UUID id
     ) {
         jwtValidatorService.validateTokenOrThrow(accessToken);
-        log.debug("get configuration {}", id);
+        log.debug("get problematic questions statistic of configuration {}", id);
         return statisticService.getProblematicQuestions(id);
     }
-
 }

--- a/src/main/java/de/unistuttgart/finitequizbackend/controller/StatisticController.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/controller/StatisticController.java
@@ -1,29 +1,23 @@
 package de.unistuttgart.finitequizbackend.controller;
 
-import de.unistuttgart.finitequizbackend.data.ConfigurationDTO;
-import de.unistuttgart.finitequizbackend.data.QuestionDTO;
-import de.unistuttgart.finitequizbackend.data.mapper.ConfigurationMapper;
-import de.unistuttgart.finitequizbackend.data.mapper.QuestionMapper;
 import de.unistuttgart.finitequizbackend.data.statistic.ProblematicQuestion;
 import de.unistuttgart.finitequizbackend.data.statistic.TimeSpentDistribution;
-import de.unistuttgart.finitequizbackend.repositories.ConfigurationRepository;
-import de.unistuttgart.finitequizbackend.service.ConfigService;
 import de.unistuttgart.finitequizbackend.service.StatisticService;
 import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
-import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
-import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 /**
  * This controller handles all game-configuration-related REST-APIs
  */
+@Tag(name = "Statistic", description = "Get statistics of minigame configurations")
 @RestController
 @RequestMapping("/statistics")
 @Import({ JWTValidatorService.class })
@@ -32,17 +26,12 @@ import org.springframework.web.bind.annotation.*;
 public class StatisticController {
 
     @Autowired
-    private ConfigurationRepository configurationRepository;
-
-    @Autowired
     private StatisticService statisticService;
-
-    @Autowired
-    private ConfigService configService;
 
     @Autowired
     private JWTValidatorService jwtValidatorService;
 
+    @Operation(summary = "Get problematic questions of a configuration")
     @GetMapping("/{id}/problematic-questions")
     public List<ProblematicQuestion> getProblematicQuestionsStatisticsOfMinigame(
         @CookieValue("access_token") final String accessToken,
@@ -53,6 +42,7 @@ public class StatisticController {
         return statisticService.getProblematicQuestions(id);
     }
 
+    @Operation(summary = "Get the time spent distribution of a configuration")
     @GetMapping("/{id}/time-spent")
     public List<TimeSpentDistribution> getTimeSpentStatistcOfMinigame(
         @CookieValue("access_token") final String accessToken,

--- a/src/main/java/de/unistuttgart/finitequizbackend/controller/StatisticController.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/controller/StatisticController.java
@@ -5,6 +5,7 @@ import de.unistuttgart.finitequizbackend.data.QuestionDTO;
 import de.unistuttgart.finitequizbackend.data.mapper.ConfigurationMapper;
 import de.unistuttgart.finitequizbackend.data.mapper.QuestionMapper;
 import de.unistuttgart.finitequizbackend.data.statistic.ProblematicQuestion;
+import de.unistuttgart.finitequizbackend.data.statistic.TimeSpentDistribution;
 import de.unistuttgart.finitequizbackend.repositories.ConfigurationRepository;
 import de.unistuttgart.finitequizbackend.service.ConfigService;
 import de.unistuttgart.finitequizbackend.service.StatisticService;
@@ -52,4 +53,15 @@ public class StatisticController {
         log.debug("get problematic questions statistic of configuration {}", id);
         return statisticService.getProblematicQuestions(id);
     }
+
+    @GetMapping("/{id}/time-spent")
+    public List<TimeSpentDistribution> getTimeSpentStatistcOfMinigame(
+            @CookieValue("access_token") final String accessToken,
+            @PathVariable final UUID id
+    ) {
+        jwtValidatorService.validateTokenOrThrow(accessToken);
+        log.debug("get time spent statistic of configuration {}", id);
+        return statisticService.getTimeSpentDistributions(id);
+    }
+
 }

--- a/src/main/java/de/unistuttgart/finitequizbackend/controller/StatisticController.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/controller/StatisticController.java
@@ -1,0 +1,56 @@
+package de.unistuttgart.finitequizbackend.controller;
+
+import de.unistuttgart.finitequizbackend.data.ConfigurationDTO;
+import de.unistuttgart.finitequizbackend.data.QuestionDTO;
+import de.unistuttgart.finitequizbackend.data.mapper.ConfigurationMapper;
+import de.unistuttgart.finitequizbackend.data.mapper.QuestionMapper;
+import de.unistuttgart.finitequizbackend.data.statistic.ProblematicQuestion;
+import de.unistuttgart.finitequizbackend.repositories.ConfigurationRepository;
+import de.unistuttgart.finitequizbackend.service.ConfigService;
+import de.unistuttgart.finitequizbackend.service.StatisticService;
+import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * This controller handles all game-configuration-related REST-APIs
+ */
+@RestController
+@RequestMapping("/statistics")
+@Import({ JWTValidatorService.class })
+@Slf4j
+@Validated
+public class StatisticController {
+
+    @Autowired
+    private ConfigurationRepository configurationRepository;
+
+    @Autowired
+    private StatisticService statisticService;
+
+    @Autowired
+    private ConfigService configService;
+
+    @Autowired
+    private JWTValidatorService jwtValidatorService;
+
+    @GetMapping("/{id}/problematic-questions")
+    public List<ProblematicQuestion> getProblematicQuestionsStatisticsOfMinigame(
+        @CookieValue("access_token") final String accessToken,
+        @PathVariable final UUID id
+    ) {
+        jwtValidatorService.validateTokenOrThrow(accessToken);
+        log.debug("get configuration {}", id);
+        return statisticService.getProblematicQuestions(id);
+    }
+
+}

--- a/src/main/java/de/unistuttgart/finitequizbackend/controller/StatisticController.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/controller/StatisticController.java
@@ -10,17 +10,16 @@ import de.unistuttgart.finitequizbackend.repositories.ConfigurationRepository;
 import de.unistuttgart.finitequizbackend.service.ConfigService;
 import de.unistuttgart.finitequizbackend.service.StatisticService;
 import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
-import javax.validation.Valid;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
 
 /**
  * This controller handles all game-configuration-related REST-APIs
@@ -56,12 +55,11 @@ public class StatisticController {
 
     @GetMapping("/{id}/time-spent")
     public List<TimeSpentDistribution> getTimeSpentStatistcOfMinigame(
-            @CookieValue("access_token") final String accessToken,
-            @PathVariable final UUID id
+        @CookieValue("access_token") final String accessToken,
+        @PathVariable final UUID id
     ) {
         jwtValidatorService.validateTokenOrThrow(accessToken);
         log.debug("get time spent statistic of configuration {}", id);
         return statisticService.getTimeSpentDistributions(id);
     }
-
 }

--- a/src/main/java/de/unistuttgart/finitequizbackend/data/GameResult.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/data/GameResult.java
@@ -81,9 +81,15 @@ public class GameResult {
     @CreationTimestamp
     private Date playedTime;
 
+    /**
+     * The time spent in seconds on the game for this run.
+     */
+    private long timeSpent;
+
     public GameResult(
         final int questionCount,
         final long score,
+        final long timeSpent,
         final List<RoundResult> correctAnsweredQuestions,
         final List<RoundResult> wrongAnsweredQuestions,
         final UUID configurationAsUUID,
@@ -91,6 +97,7 @@ public class GameResult {
     ) {
         this.questionCount = questionCount;
         this.score = score;
+        this.timeSpent = timeSpent;
         this.correctAnsweredQuestions = correctAnsweredQuestions;
         this.wrongAnsweredQuestions = wrongAnsweredQuestions;
         this.configurationAsUUID = configurationAsUUID;

--- a/src/main/java/de/unistuttgart/finitequizbackend/data/GameResult.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/data/GameResult.java
@@ -2,6 +2,7 @@ package de.unistuttgart.finitequizbackend.data;
 
 import de.unistuttgart.finitequizbackend.Constants;
 import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import javax.persistence.*;
@@ -13,6 +14,7 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
+import org.hibernate.annotations.CreationTimestamp;
 import org.springframework.validation.annotation.Validated;
 
 /**
@@ -76,7 +78,8 @@ public class GameResult {
     private String playerId;
 
     @NotNull(message = "playedTime cannot be null")
-    private LocalDateTime playedTime;
+    @CreationTimestamp
+    private Date playedTime;
 
     public GameResult(
         final int questionCount,
@@ -92,6 +95,5 @@ public class GameResult {
         this.wrongAnsweredQuestions = wrongAnsweredQuestions;
         this.configurationAsUUID = configurationAsUUID;
         this.playerId = playerId;
-        this.playedTime = LocalDateTime.now();
     }
 }

--- a/src/main/java/de/unistuttgart/finitequizbackend/data/GameResult.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/data/GameResult.java
@@ -79,7 +79,7 @@ public class GameResult {
 
     @NotNull(message = "playedTime cannot be null")
     @CreationTimestamp
-    private Date playedTime;
+    private Date playedTime = new Date();
 
     /**
      * The time spent in seconds on the game for this run.

--- a/src/main/java/de/unistuttgart/finitequizbackend/data/GameResultDTO.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/data/GameResultDTO.java
@@ -69,15 +69,22 @@ public class GameResultDTO {
     @NotNull(message = "configurationAsUUID cannot be null")
     private UUID configurationAsUUID;
 
+    /**
+     * The time spent in seconds on the game for this run.
+     */
+    private long timeSpent;
+
     public GameResultDTO(
         final int questionCount,
         final long score,
+        final long timeSpent,
         final List<RoundResultDTO> correctAnsweredQuestions,
         final List<RoundResultDTO> wrongAnsweredQuestions,
         final UUID configurationAsUUID
     ) {
         this.questionCount = questionCount;
         this.score = score;
+        this.timeSpent = timeSpent;
         this.correctAnsweredQuestions = correctAnsweredQuestions;
         this.wrongAnsweredQuestions = wrongAnsweredQuestions;
         this.configurationAsUUID = configurationAsUUID;

--- a/src/main/java/de/unistuttgart/finitequizbackend/data/OverworldResultDTO.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/data/OverworldResultDTO.java
@@ -24,7 +24,7 @@ public class OverworldResultDTO {
      * The name of the minigame. In this case "FINITEQUIZ".
      */
     @NotNull(message = "game cannot be null")
-    String game;
+    final String game = "FINITEQUIZ";
 
     /**
      * The ID of the configuration that was used for the game.

--- a/src/main/java/de/unistuttgart/finitequizbackend/data/statistic/ProblematicQuestion.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/data/statistic/ProblematicQuestion.java
@@ -1,0 +1,32 @@
+package de.unistuttgart.finitequizbackend.data.statistic;
+
+import de.unistuttgart.finitequizbackend.data.QuestionDTO;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class ProblematicQuestion {
+
+    int attempts;
+    int correctAnswers;
+    int wrongAnswers;
+
+    QuestionDTO question;
+
+    public void addCorrectAnswer() {
+        correctAnswers++;
+        attempts++;
+    }
+
+    public void addWrongAnswer() {
+        wrongAnswers++;
+        attempts++;
+    }
+
+}

--- a/src/main/java/de/unistuttgart/finitequizbackend/data/statistic/ProblematicQuestion.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/data/statistic/ProblematicQuestion.java
@@ -28,5 +28,4 @@ public class ProblematicQuestion {
         wrongAnswers++;
         attempts++;
     }
-
 }

--- a/src/main/java/de/unistuttgart/finitequizbackend/data/statistic/TimeSpentDistribution.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/data/statistic/TimeSpentDistribution.java
@@ -15,20 +15,20 @@ public class TimeSpentDistribution {
     /**
      * The start of the percentage of game results that took between fromTime and toTime to finish.
      */
-    long fromPercentage;
+    double fromPercentage;
     /**
      * The end of the percentage of game results that took between fromTime and toTime to finish.
      */
-    long toPercentage;
+    double toPercentage;
 
     /**
      * The lower bound of time game results that spent time on the quiz.
      */
-    long fromTime;
+    double fromTime;
     /**
      * The upper bound of time game results that spent time on the quiz.
      */
-    long toTime;
+    double toTime;
 
     /**
      * The amount of game results that took between fromTime and toTime to finish.

--- a/src/main/java/de/unistuttgart/finitequizbackend/data/statistic/TimeSpentDistribution.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/data/statistic/TimeSpentDistribution.java
@@ -38,5 +38,4 @@ public class TimeSpentDistribution {
     public void addCount() {
         count++;
     }
-
 }

--- a/src/main/java/de/unistuttgart/finitequizbackend/data/statistic/TimeSpentDistribution.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/data/statistic/TimeSpentDistribution.java
@@ -1,0 +1,42 @@
+package de.unistuttgart.finitequizbackend.data.statistic;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class TimeSpentDistribution {
+
+    /**
+     * The start of the percentage of game results that took between fromTime and toTime to finish.
+     */
+    long fromPercentage;
+    /**
+     * The end of the percentage of game results that took between fromTime and toTime to finish.
+     */
+    long toPercentage;
+
+    /**
+     * The lower bound of time game results that spent time on the quiz.
+     */
+    long fromTime;
+    /**
+     * The upper bound of time game results that spent time on the quiz.
+     */
+    long toTime;
+
+    /**
+     * The amount of game results that took between fromTime and toTime to finish.
+     */
+    int count;
+
+    public void addCount() {
+        count++;
+    }
+
+}

--- a/src/main/java/de/unistuttgart/finitequizbackend/repositories/GameResultRepository.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/repositories/GameResultRepository.java
@@ -1,15 +1,12 @@
 package de.unistuttgart.finitequizbackend.repositories;
 
 import de.unistuttgart.finitequizbackend.data.GameResult;
+import java.util.List;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.UUID;
-
 @Repository
 public interface GameResultRepository extends JpaRepository<GameResult, Long> {
-
     List<GameResult> findByConfigurationAsUUID(UUID configurationId);
-
 }

--- a/src/main/java/de/unistuttgart/finitequizbackend/repositories/GameResultRepository.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/repositories/GameResultRepository.java
@@ -4,5 +4,12 @@ import de.unistuttgart.finitequizbackend.data.GameResult;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.UUID;
+
 @Repository
-public interface GameResultRepository extends JpaRepository<GameResult, Long> {}
+public interface GameResultRepository extends JpaRepository<GameResult, Long> {
+
+    List<GameResult> findByConfigurationAsUUID(UUID configurationId);
+
+}

--- a/src/main/java/de/unistuttgart/finitequizbackend/service/GameResultService.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/service/GameResultService.java
@@ -85,6 +85,7 @@ public class GameResultService {
             final GameResult result = new @Valid GameResult(
                 gameResultDTO.getQuestionCount(),
                 gameResultDTO.getScore(),
+                gameResultDTO.getTimeSpent(),
                 correctQuestions,
                 wrongQuestions,
                 gameResultDTO.getConfigurationAsUUID(),

--- a/src/main/java/de/unistuttgart/finitequizbackend/service/GameResultService.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/service/GameResultService.java
@@ -73,7 +73,6 @@ public class GameResultService {
             gameResultDTO.getQuestionCount()
         );
         final OverworldResultDTO resultDTO = new OverworldResultDTO(
-            "FINITEQUIZ",
             gameResultDTO.getConfigurationAsUUID(),
             resultScore,
             userId
@@ -112,7 +111,7 @@ public class GameResultService {
      * @return score as int in %
      * @throws IllegalArgumentException if correctAnswers < 0 || numberOfQuestions < correctAnswers
      */
-    private int calculateResultScore(final int correctAnswers, final int numberOfQuestions) {
+    public int calculateResultScore(final int correctAnswers, final int numberOfQuestions) {
         if (correctAnswers < 0 || numberOfQuestions < correctAnswers) {
             throw new IllegalArgumentException(
                 String.format(

--- a/src/main/java/de/unistuttgart/finitequizbackend/service/GameResultService.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/service/GameResultService.java
@@ -64,7 +64,11 @@ public class GameResultService {
      * @param accessToken accessToken of the user
      * @throws IllegalArgumentException if at least one of the arguments is null
      */
-    public void saveGameResult(final @Valid GameResultDTO gameResultDTO, final String userId, final String accessToken) {
+    public void saveGameResult(
+        final @Valid GameResultDTO gameResultDTO,
+        final String userId,
+        final String accessToken
+    ) {
         if (gameResultDTO == null || userId == null || accessToken == null) {
             throw new IllegalArgumentException("gameResultDTO or userId is null");
         }

--- a/src/main/java/de/unistuttgart/finitequizbackend/service/StatisticService.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/service/StatisticService.java
@@ -32,6 +32,12 @@ public class StatisticService {
     @Autowired
     private GameResultRepository gameResultRepository;
 
+    /**
+     * Returns a list of the most problematic questions of a minigame
+     *
+     * @param configurationId the configuration id of the minigame
+     * @return a list of the most problematic questions of a minigame
+     */
     public List<ProblematicQuestion> getProblematicQuestions(UUID configurationId) {
         Configuration configuration = configService.getConfiguration(configurationId);
         List<GameResult> gameResults = gameResultRepository.findByConfigurationAsUUID(configurationId);

--- a/src/main/java/de/unistuttgart/finitequizbackend/service/StatisticService.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/service/StatisticService.java
@@ -5,6 +5,7 @@ import de.unistuttgart.finitequizbackend.data.GameResult;
 import de.unistuttgart.finitequizbackend.data.Question;
 import de.unistuttgart.finitequizbackend.data.mapper.QuestionMapper;
 import de.unistuttgart.finitequizbackend.data.statistic.ProblematicQuestion;
+import de.unistuttgart.finitequizbackend.data.statistic.TimeSpentDistribution;
 import de.unistuttgart.finitequizbackend.repositories.GameResultRepository;
 import de.unistuttgart.finitequizbackend.repositories.QuestionRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +23,7 @@ import java.util.UUID;
 public class StatisticService {
 
     static final int MAX_PROBLEMATIC_QUESTIONS = 5;
+    static final int[] TIME_SPENT_DISTRIBUTION_PERCENTAGES = { 0, 10, 50, 90, 100};
 
 
     @Autowired
@@ -38,15 +40,15 @@ public class StatisticService {
      * @param configurationId the configuration id of the minigame
      * @return a list of the most problematic questions of a minigame
      */
-    public List<ProblematicQuestion> getProblematicQuestions(UUID configurationId) {
-        Configuration configuration = configService.getConfiguration(configurationId);
-        List<GameResult> gameResults = gameResultRepository.findByConfigurationAsUUID(configurationId);
-        List<ProblematicQuestion> problematicQuestions = new ArrayList<>();
+    public List<ProblematicQuestion> getProblematicQuestions(final UUID configurationId) {
+        final Configuration configuration = configService.getConfiguration(configurationId);
+        final List<GameResult> gameResults = gameResultRepository.findByConfigurationAsUUID(configurationId);
+        final List<ProblematicQuestion> problematicQuestions = new ArrayList<>();
         for (Question question : configuration.getQuestions()) {
             problematicQuestions.add(new ProblematicQuestion(0, 0, 0, questionMapper.questionToQuestionDTO(question)));
         }
 
-        for (GameResult gameResult : gameResults) {
+        for (final GameResult gameResult : gameResults) {
             // iterate over all wrong answered round results and add wrong answered counter for this problematic question
             gameResult.getWrongAnsweredQuestions().forEach(roundResult -> {
                 problematicQuestions.stream().filter(problematicQuestion -> problematicQuestion.getQuestion().getId().equals(roundResult.getQuestion().getId()))
@@ -77,5 +79,51 @@ public class StatisticService {
         });
 
         return problematicQuestions.subList(0, Math.min(MAX_PROBLEMATIC_QUESTIONS, problematicQuestions.size()));
+    }
+
+    /**
+     * Returns a list of the time spent distribution of a minigame
+     *
+     * @param configurationId the configuration id of the minigame
+     * @return a list of the time spent distribution of a minigame
+     */
+    public List<TimeSpentDistribution> getTimeSpentDistributions(final UUID configurationId) {
+        final List<GameResult> gameResults = gameResultRepository.findByConfigurationAsUUID(configurationId);
+        final List<TimeSpentDistribution> timeSpentDistributions = new ArrayList<>();
+        for (int i = 0; i < TIME_SPENT_DISTRIBUTION_PERCENTAGES.length - 1; i++) {
+            TimeSpentDistribution timeSpentDistribution = new TimeSpentDistribution();
+            timeSpentDistribution.setFromPercentage(TIME_SPENT_DISTRIBUTION_PERCENTAGES[i]);
+            timeSpentDistribution.setToPercentage(TIME_SPENT_DISTRIBUTION_PERCENTAGES[i + 1]);
+            timeSpentDistributions.add(timeSpentDistribution);
+        }
+        // order game results by time spent
+        gameResults.sort((o1, o2) -> {
+            if (o1.getTimeSpent() > o2.getTimeSpent()) {
+                return 1;
+            } else if (o1.getTimeSpent() < o2.getTimeSpent()) {
+                return -1;
+            } else {
+                return 0;
+            }
+        });
+
+        // calculate time spent time borders to time spent distribution percentage
+        int currentGameResultIndex = 0;
+        // TODO: make this work that every timedistrubution has the correct amount of counts
+        for (TimeSpentDistribution timeSpentDistribution : timeSpentDistributions) {
+            GameResult gameResult = null;
+            while (currentGameResultIndex <= (timeSpentDistribution.getToPercentage() / 100L) * gameResults.size() && currentGameResultIndex < gameResults.size()) {
+                gameResult = gameResults.get(currentGameResultIndex);
+                if (timeSpentDistribution.getFromTime() == 0) {
+                    timeSpentDistribution.setFromTime(gameResult.getTimeSpent());
+                }
+                timeSpentDistribution.addCount();
+                currentGameResultIndex++;
+            }
+            if (gameResult != null) {
+                timeSpentDistribution.setToTime(gameResult.getTimeSpent());
+            }
+        }
+        return timeSpentDistributions;
     }
 }

--- a/src/main/java/de/unistuttgart/finitequizbackend/service/StatisticService.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/service/StatisticService.java
@@ -8,14 +8,13 @@ import de.unistuttgart.finitequizbackend.data.statistic.ProblematicQuestion;
 import de.unistuttgart.finitequizbackend.data.statistic.TimeSpentDistribution;
 import de.unistuttgart.finitequizbackend.repositories.GameResultRepository;
 import de.unistuttgart.finitequizbackend.repositories.QuestionRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 
 @Service
 @Slf4j
@@ -23,14 +22,14 @@ import java.util.UUID;
 public class StatisticService {
 
     static final int MAX_PROBLEMATIC_QUESTIONS = 5;
-    static final int[] TIME_SPENT_DISTRIBUTION_PERCENTAGES = { 0, 10, 50, 90, 100};
-
+    static final int[] TIME_SPENT_DISTRIBUTION_PERCENTAGES = { 0, 10, 50, 90, 100 };
 
     @Autowired
     private ConfigService configService;
 
     @Autowired
     private QuestionMapper questionMapper;
+
     @Autowired
     private GameResultRepository gameResultRepository;
 
@@ -50,20 +49,34 @@ public class StatisticService {
 
         for (final GameResult gameResult : gameResults) {
             // iterate over all wrong answered round results and add wrong answered counter for this problematic question
-            gameResult.getWrongAnsweredQuestions().forEach(roundResult -> {
-                problematicQuestions.stream().filter(problematicQuestion -> problematicQuestion.getQuestion().getId().equals(roundResult.getQuestion().getId()))
-                        .findAny().ifPresent(problematicQuestion -> {
+            gameResult
+                .getWrongAnsweredQuestions()
+                .forEach(roundResult -> {
+                    problematicQuestions
+                        .stream()
+                        .filter(problematicQuestion ->
+                            problematicQuestion.getQuestion().getId().equals(roundResult.getQuestion().getId())
+                        )
+                        .findAny()
+                        .ifPresent(problematicQuestion -> {
                             problematicQuestion.addWrongAnswer();
                         });
-            });
+                });
 
             // iterate over all correct answered round results and add correct answered counter for this problematic question
-            gameResult.getCorrectAnsweredQuestions().forEach(roundResult -> {
-                problematicQuestions.stream().filter(problematicQuestion -> problematicQuestion.getQuestion().getId().equals(roundResult.getQuestion().getId()))
-                        .findAny().ifPresent(problematicQuestion -> {
+            gameResult
+                .getCorrectAnsweredQuestions()
+                .forEach(roundResult -> {
+                    problematicQuestions
+                        .stream()
+                        .filter(problematicQuestion ->
+                            problematicQuestion.getQuestion().getId().equals(roundResult.getQuestion().getId())
+                        )
+                        .findAny()
+                        .ifPresent(problematicQuestion -> {
                             problematicQuestion.addCorrectAnswer();
                         });
-            });
+                });
         }
 
         problematicQuestions.sort((o1, o2) -> {
@@ -112,7 +125,10 @@ public class StatisticService {
         // TODO: make this work that every timedistrubution has the correct amount of counts
         for (TimeSpentDistribution timeSpentDistribution : timeSpentDistributions) {
             GameResult gameResult = null;
-            while (currentGameResultIndex <= (timeSpentDistribution.getToPercentage() / 100L) * gameResults.size() && currentGameResultIndex < gameResults.size()) {
+            while (
+                currentGameResultIndex <= (timeSpentDistribution.getToPercentage() / 100L) * gameResults.size() &&
+                currentGameResultIndex < gameResults.size()
+            ) {
                 gameResult = gameResults.get(currentGameResultIndex);
                 if (timeSpentDistribution.getFromTime() == 0) {
                     timeSpentDistribution.setFromTime(gameResult.getTimeSpent());

--- a/src/main/java/de/unistuttgart/finitequizbackend/service/StatisticService.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/service/StatisticService.java
@@ -1,0 +1,75 @@
+package de.unistuttgart.finitequizbackend.service;
+
+import de.unistuttgart.finitequizbackend.data.Configuration;
+import de.unistuttgart.finitequizbackend.data.GameResult;
+import de.unistuttgart.finitequizbackend.data.Question;
+import de.unistuttgart.finitequizbackend.data.mapper.QuestionMapper;
+import de.unistuttgart.finitequizbackend.data.statistic.ProblematicQuestion;
+import de.unistuttgart.finitequizbackend.repositories.GameResultRepository;
+import de.unistuttgart.finitequizbackend.repositories.QuestionRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@Transactional
+public class StatisticService {
+
+    static final int MAX_PROBLEMATIC_QUESTIONS = 5;
+
+
+    @Autowired
+    private ConfigService configService;
+
+    @Autowired
+    private QuestionMapper questionMapper;
+    @Autowired
+    private GameResultRepository gameResultRepository;
+
+    public List<ProblematicQuestion> getProblematicQuestions(UUID configurationId) {
+        Configuration configuration = configService.getConfiguration(configurationId);
+        List<GameResult> gameResults = gameResultRepository.findByConfigurationAsUUID(configurationId);
+        List<ProblematicQuestion> problematicQuestions = new ArrayList<>();
+        for (Question question : configuration.getQuestions()) {
+            problematicQuestions.add(new ProblematicQuestion(0, 0, 0, questionMapper.questionToQuestionDTO(question)));
+        }
+
+        for (GameResult gameResult : gameResults) {
+            // iterate over all wrong answered round results and add wrong answered counter for this problematic question
+            gameResult.getWrongAnsweredQuestions().forEach(roundResult -> {
+                problematicQuestions.stream().filter(problematicQuestion -> problematicQuestion.getQuestion().getId().equals(roundResult.getQuestion().getId()))
+                        .findAny().ifPresent(problematicQuestion -> {
+                            problematicQuestion.addWrongAnswer();
+                        });
+            });
+
+            // iterate over all correct answered round results and add correct answered counter for this problematic question
+            gameResult.getCorrectAnsweredQuestions().forEach(roundResult -> {
+                problematicQuestions.stream().filter(problematicQuestion -> problematicQuestion.getQuestion().getId().equals(roundResult.getQuestion().getId()))
+                        .findAny().ifPresent(problematicQuestion -> {
+                            problematicQuestion.addCorrectAnswer();
+                        });
+            });
+        }
+
+        problematicQuestions.sort((o1, o2) -> {
+            double percantageWrong1 = (double) o1.getWrongAnswers() / (double) o1.getAttempts();
+            double percantageWrong2 = (double) o2.getWrongAnswers() / (double) o2.getAttempts();
+            if (percantageWrong1 > percantageWrong2) {
+                return -1;
+            } else if (percantageWrong1 < percantageWrong2) {
+                return 1;
+            } else {
+                return 0;
+            }
+        });
+
+        return problematicQuestions.subList(0, Math.min(MAX_PROBLEMATIC_QUESTIONS, problematicQuestions.size()));
+    }
+}

--- a/src/main/java/de/unistuttgart/finitequizbackend/service/StatisticService.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/service/StatisticService.java
@@ -22,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class StatisticService {
 
     static final int MAX_PROBLEMATIC_QUESTIONS = 5;
-    static final int[] TIME_SPENT_DISTRIBUTION_PERCENTAGES = { 0, 10, 50, 90, 100 };
+    static final int[] TIME_SPENT_DISTRIBUTION_PERCENTAGES = { 0, 25, 50, 75, 100 };
 
     @Autowired
     private ConfigService configService;
@@ -101,6 +101,15 @@ public class StatisticService {
      * @return a list of the time spent distribution of a minigame
      */
     public List<TimeSpentDistribution> getTimeSpentDistributions(final UUID configurationId) {
+        if (TIME_SPENT_DISTRIBUTION_PERCENTAGES.length < 2) {
+            throw new IllegalArgumentException("TIME_SPENT_DISTRIBUTION_PERCENTAGES must have at least 2 elements");
+        }
+        if (TIME_SPENT_DISTRIBUTION_PERCENTAGES[0] != 0) {
+            throw new IllegalArgumentException("TIME_SPENT_DISTRIBUTION_PERCENTAGES must start with 0");
+        }
+        if (TIME_SPENT_DISTRIBUTION_PERCENTAGES[TIME_SPENT_DISTRIBUTION_PERCENTAGES.length - 1] != 100) {
+            throw new IllegalArgumentException("TIME_SPENT_DISTRIBUTION_PERCENTAGES must end with 100");
+        }
         final List<GameResult> gameResults = gameResultRepository.findByConfigurationAsUUID(configurationId);
         final List<TimeSpentDistribution> timeSpentDistributions = new ArrayList<>();
         for (int i = 0; i < TIME_SPENT_DISTRIBUTION_PERCENTAGES.length - 1; i++) {
@@ -125,10 +134,7 @@ public class StatisticService {
         // TODO: make this work that every timedistrubution has the correct amount of counts
         for (TimeSpentDistribution timeSpentDistribution : timeSpentDistributions) {
             GameResult gameResult = null;
-            while (
-                currentGameResultIndex <= (timeSpentDistribution.getToPercentage() / 100L) * gameResults.size() &&
-                currentGameResultIndex < gameResults.size()
-            ) {
+            while (currentGameResultIndex < (timeSpentDistribution.getToPercentage() / 100.0) * gameResults.size()) {
                 gameResult = gameResults.get(currentGameResultIndex);
                 if (timeSpentDistribution.getFromTime() == 0) {
                     timeSpentDistribution.setFromTime(gameResult.getTimeSpent());

--- a/src/test/java/de/unistuttgart/finitequizbackend/GameResultControllerTest.java
+++ b/src/test/java/de/unistuttgart/finitequizbackend/GameResultControllerTest.java
@@ -123,7 +123,7 @@ class GameResultControllerTest {
         wrongList.add(
             new RoundResultDTO(initialQuestion2.getId(), initialQuestion2.getWrongAnswers().stream().findFirst().get())
         );
-        final GameResultDTO gameResultDTO = new GameResultDTO(2, 1, correctList, wrongList, UUID.randomUUID());
+        final GameResultDTO gameResultDTO = new GameResultDTO(2, 1, 30, correctList, wrongList, UUID.randomUUID());
 
         final String bodyValue = objectMapper.writeValueAsString(gameResultDTO);
         final MvcResult result = mvc

--- a/src/test/java/de/unistuttgart/finitequizbackend/GameResultControllerTest.java
+++ b/src/test/java/de/unistuttgart/finitequizbackend/GameResultControllerTest.java
@@ -76,6 +76,7 @@ class GameResultControllerTest {
     @BeforeEach
     public void createBasicData() throws IOException {
         ResultMocks.setupMockBooksResponse(mockResultsService);
+        gameResultRepository.deleteAll();
         configurationRepository.deleteAll();
         initialQuestion1 = new Question();
         initialQuestion1.setText("Are you cool?");

--- a/src/test/java/de/unistuttgart/finitequizbackend/statistic/StatisticTest.java
+++ b/src/test/java/de/unistuttgart/finitequizbackend/statistic/StatisticTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import de.unistuttgart.finitequizbackend.data.*;
 import de.unistuttgart.finitequizbackend.data.mapper.QuestionMapper;
 import de.unistuttgart.finitequizbackend.data.statistic.ProblematicQuestion;
+import de.unistuttgart.finitequizbackend.data.statistic.TimeSpentDistribution;
 import de.unistuttgart.finitequizbackend.repositories.ConfigurationRepository;
 import de.unistuttgart.finitequizbackend.repositories.GameResultRepository;
 import de.unistuttgart.finitequizbackend.service.GameResultService;
@@ -120,6 +121,7 @@ public class StatisticTest {
         }
         gameResult1.setCorrectAnsweredQuestions(rightAnswers1);
         gameResult1.setWrongAnsweredQuestions(wrongAnswers1);
+        gameResult1.setTimeSpent(60);
 
         GameResult gameResult2 = new GameResult();
         gameResult2.setConfigurationAsUUID(staticConfiguration.getId());
@@ -133,6 +135,7 @@ public class StatisticTest {
         }
         gameResult2.setCorrectAnsweredQuestions(rightAnswers2);
         gameResult2.setWrongAnsweredQuestions(wrongAnswers2);
+        gameResult2.setTimeSpent(100);
 
         GameResult gameResult3 = new GameResult();
         gameResult3.setConfigurationAsUUID(staticConfiguration.getId());
@@ -148,6 +151,7 @@ public class StatisticTest {
         }
         gameResult3.setCorrectAnsweredQuestions(rightAnswers3);
         gameResult3.setWrongAnsweredQuestions(wrongAnswers3);
+        gameResult3.setTimeSpent(200);
 
         GameResult gameResult4 = new GameResult();
         gameResult4.setConfigurationAsUUID(staticConfiguration.getId());
@@ -163,6 +167,7 @@ public class StatisticTest {
         }
         gameResult4.setCorrectAnsweredQuestions(rightAnswers4);
         gameResult4.setWrongAnsweredQuestions(wrongAnswers4);
+        gameResult4.setTimeSpent(300);
 
         problematicQuestion = questionMapper.questionToQuestionDTO(questionList.get(5));
         bestAnsweredQuestion = questionMapper.questionToQuestionDTO(questionList.get(0));
@@ -175,7 +180,7 @@ public class StatisticTest {
     }
 
     @Test
-    public void testGetAllGameResults() throws Exception {
+    public void testGetProblematicQuestions() throws Exception {
         final MvcResult result = mvc
                 .perform(get(API_URL + "/" + staticConfiguration.getId() + "/problematic-questions").cookie(cookie).contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -195,5 +200,19 @@ public class StatisticTest {
         assertFalse(problematicQuestions.stream().map(ProblematicQuestion::getQuestion).anyMatch(question -> question.equals(bestAnsweredQuestion)));
         assertEquals(problematicQuestion, problematicQuestions.get(0).getQuestion());
         assertSame(5, problematicQuestions.size());
+    }
+
+    @Test
+    public void testGetTimeSpentDistribution() throws Exception {
+        final MvcResult result = mvc
+                .perform(get(API_URL + "/" + staticConfiguration.getId() + "/time-spent").cookie(cookie).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        final List<TimeSpentDistribution> timeSpentDistributions = Arrays.asList(
+                objectMapper.readValue(result.getResponse().getContentAsString(), TimeSpentDistribution[].class)
+        );
+
+        // TODO: make good tests
     }
 }

--- a/src/test/java/de/unistuttgart/finitequizbackend/statistic/StatisticTest.java
+++ b/src/test/java/de/unistuttgart/finitequizbackend/statistic/StatisticTest.java
@@ -58,6 +58,7 @@ public class StatisticTest {
 
     private Configuration randomConfiguration;
     private Configuration staticConfiguration;
+    int numberOfGameResultsOfStaticConfiguration;
     private QuestionDTO problematicQuestion;
     private QuestionDTO bestAnsweredQuestion;
     private List<GameResult> gameResults;
@@ -170,6 +171,8 @@ public class StatisticTest {
         gameResult4.setWrongAnsweredQuestions(wrongAnswers4);
         gameResult4.setTimeSpent(300);
 
+        numberOfGameResultsOfStaticConfiguration = 4;
+
         problematicQuestion = questionMapper.questionToQuestionDTO(questionList.get(5));
         bestAnsweredQuestion = questionMapper.questionToQuestionDTO(questionList.get(0));
 
@@ -224,6 +227,7 @@ public class StatisticTest {
         final List<TimeSpentDistribution> timeSpentDistributions = Arrays.asList(
             objectMapper.readValue(result.getResponse().getContentAsString(), TimeSpentDistribution[].class)
         );
-        // TODO: make good tests
+        long amountOfGameResults = timeSpentDistributions.stream().map(TimeSpentDistribution::getCount).count();
+        assertEquals(numberOfGameResultsOfStaticConfiguration, amountOfGameResults);
     }
 }

--- a/src/test/java/de/unistuttgart/finitequizbackend/statistic/StatisticTest.java
+++ b/src/test/java/de/unistuttgart/finitequizbackend/statistic/StatisticTest.java
@@ -1,0 +1,199 @@
+package de.unistuttgart.finitequizbackend.statistic;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.unistuttgart.finitequizbackend.data.*;
+import de.unistuttgart.finitequizbackend.data.mapper.QuestionMapper;
+import de.unistuttgart.finitequizbackend.data.statistic.ProblematicQuestion;
+import de.unistuttgart.finitequizbackend.repositories.ConfigurationRepository;
+import de.unistuttgart.finitequizbackend.repositories.GameResultRepository;
+import de.unistuttgart.finitequizbackend.service.GameResultService;
+import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import javax.servlet.http.Cookie;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class StatisticTest {
+
+    private final String API_URL = "/statistics";
+
+    @MockBean
+    JWTValidatorService jwtValidatorService;
+
+    Cookie cookie = new Cookie("access_token", "testToken");
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private GameResultRepository gameResultRepository;
+
+    @Autowired
+    private GameResultService gameResultService;
+    @Autowired
+    private QuestionMapper questionMapper;
+
+    @Autowired
+    private ConfigurationRepository configurationRepository;
+    private ObjectMapper objectMapper;
+
+    private Configuration randomConfiguration;
+    private Configuration staticConfiguration;
+    private QuestionDTO problematicQuestion;
+    private QuestionDTO bestAnsweredQuestion;
+    private List<GameResult> gameResults;
+
+    @BeforeEach
+    public void createBasicData() {
+        gameResultRepository.deleteAll();
+
+        Set<Question> questions = new HashSet<>();
+        for (int i = 0; i < 6; i++) {
+            questions.add(new Question("question" + i, "answer" + i, Set.of("answer2", "answer3", "answer4")));
+        }
+
+        randomConfiguration = new Configuration();
+        randomConfiguration.setQuestions(questions);
+        randomConfiguration = configurationRepository.save(randomConfiguration);
+
+        gameResults = new ArrayList<>();
+
+        for (int i = 0; i < 100; i++) {
+            GameResult gameResult = new GameResult();
+            gameResult.setConfigurationAsUUID(randomConfiguration.getId());
+            gameResult.setPlayerId(UUID.randomUUID().toString());
+            gameResult.setPlayedTime(new Date());
+            List<RoundResult> wrongAnswers = new ArrayList<>();
+            List<RoundResult> correctAnswers = new ArrayList<>();
+            for (Question question : randomConfiguration.getQuestions()) {
+                if (new Random().nextInt(10) > 3) {
+                    correctAnswers.add(new RoundResult(question, question.getRightAnswer()));
+                } else {
+                    wrongAnswers.add(new RoundResult(question, UUID.randomUUID().toString()));
+                }
+            }
+            gameResult.setCorrectAnsweredQuestions(correctAnswers);
+            gameResult.setWrongAnsweredQuestions(wrongAnswers);
+            gameResult.setQuestionCount(questions.size());
+            gameResult.setScore(gameResultService.calculateResultScore(correctAnswers.size(), questions.size()));
+            gameResult = gameResultRepository.save(gameResult);
+            gameResults.add(gameResult);
+        }
+
+        questions = new HashSet<>();
+        for (int i = 0; i < 6; i++) {
+            questions.add(new Question("question" + i, "answer" + i, Set.of("answer2", "answer3", "answer4")));
+        }
+
+        staticConfiguration = new Configuration();
+        staticConfiguration.setQuestions(questions);
+        staticConfiguration = configurationRepository.save(staticConfiguration);
+
+        List<Question> questionList = questions.stream().toList();
+
+        GameResult gameResult1 = new GameResult();
+        gameResult1.setConfigurationAsUUID(staticConfiguration.getId());
+        gameResult1.setPlayerId(UUID.randomUUID().toString());
+        gameResult1.setPlayedTime(new Date());
+        List<RoundResult> wrongAnswers1 = new ArrayList<>();
+        List<RoundResult> rightAnswers1 = new ArrayList<>();
+        rightAnswers1.add(new RoundResult(questionList.get(0), questionList.get(0).getRightAnswer()));
+        for (int i = 1; i < questionList.size(); i++) {
+            wrongAnswers1.add(new RoundResult(questionList.get(i), UUID.randomUUID().toString()));
+        }
+        gameResult1.setCorrectAnsweredQuestions(rightAnswers1);
+        gameResult1.setWrongAnsweredQuestions(wrongAnswers1);
+
+        GameResult gameResult2 = new GameResult();
+        gameResult2.setConfigurationAsUUID(staticConfiguration.getId());
+        gameResult2.setPlayerId(UUID.randomUUID().toString());
+        gameResult2.setPlayedTime(new Date());
+        List<RoundResult> wrongAnswers2 = new ArrayList<>();
+        List<RoundResult> rightAnswers2 = new ArrayList<>();
+        rightAnswers2.add(new RoundResult(questionList.get(0), questionList.get(0).getRightAnswer()));
+        for (int i = 1; i < questionList.size(); i++) {
+            wrongAnswers2.add(new RoundResult(questionList.get(i), UUID.randomUUID().toString()));
+        }
+        gameResult2.setCorrectAnsweredQuestions(rightAnswers2);
+        gameResult2.setWrongAnsweredQuestions(wrongAnswers2);
+
+        GameResult gameResult3 = new GameResult();
+        gameResult3.setConfigurationAsUUID(staticConfiguration.getId());
+        gameResult3.setPlayerId(UUID.randomUUID().toString());
+        gameResult3.setPlayedTime(new Date());
+        List<RoundResult> wrongAnswers3 = new ArrayList<>();
+        List<RoundResult> rightAnswers3 = new ArrayList<>();
+        for (int i = 0 ; i < 2; i++) {
+            rightAnswers3.add(new RoundResult(questionList.get(i), questionList.get(i).getRightAnswer()));
+        }
+        for (int i = 2; i < questionList.size(); i++) {
+            wrongAnswers3.add(new RoundResult(questionList.get(i), UUID.randomUUID().toString()));
+        }
+        gameResult3.setCorrectAnsweredQuestions(rightAnswers3);
+        gameResult3.setWrongAnsweredQuestions(wrongAnswers3);
+
+        GameResult gameResult4 = new GameResult();
+        gameResult4.setConfigurationAsUUID(staticConfiguration.getId());
+        gameResult4.setPlayerId(UUID.randomUUID().toString());
+        gameResult4.setPlayedTime(new Date());
+        List<RoundResult> wrongAnswers4 = new ArrayList<>();
+        List<RoundResult> rightAnswers4 = new ArrayList<>();
+        for (int i = 0 ; i < 5; i++) {
+            rightAnswers4.add(new RoundResult(questionList.get(i), questionList.get(i).getRightAnswer()));
+        }
+        for (int i = 5; i < questionList.size(); i++) {
+            wrongAnswers4.add(new RoundResult(questionList.get(i), UUID.randomUUID().toString()));
+        }
+        gameResult4.setCorrectAnsweredQuestions(rightAnswers4);
+        gameResult4.setWrongAnsweredQuestions(wrongAnswers4);
+
+        problematicQuestion = questionMapper.questionToQuestionDTO(questionList.get(5));
+        bestAnsweredQuestion = questionMapper.questionToQuestionDTO(questionList.get(0));
+
+        gameResultRepository.saveAll(List.of(gameResult1, gameResult2, gameResult3, gameResult4));
+
+
+        objectMapper = new ObjectMapper();
+        doNothing().when(jwtValidatorService).validateTokenOrThrow("testToken");
+    }
+
+    @Test
+    public void testGetAllGameResults() throws Exception {
+        final MvcResult result = mvc
+                .perform(get(API_URL + "/" + staticConfiguration.getId() + "/problematic-questions").cookie(cookie).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        final List<ProblematicQuestion> problematicQuestions = Arrays.asList(
+                objectMapper.readValue(result.getResponse().getContentAsString(), ProblematicQuestion[].class)
+        );
+
+
+
+        for (int i = 0; i < problematicQuestions.size() - 1; i++) {
+            assertTrue(problematicQuestions.get(i).getWrongAnswers() >= problematicQuestions.get(i+1).getWrongAnswers());
+        }
+
+
+        assertFalse(problematicQuestions.stream().map(ProblematicQuestion::getQuestion).anyMatch(question -> question.equals(bestAnsweredQuestion)));
+        assertEquals(problematicQuestion, problematicQuestions.get(0).getQuestion());
+        assertSame(5, problematicQuestions.size());
+    }
+}

--- a/src/test/java/de/unistuttgart/finitequizbackend/statistic/StatisticTest.java
+++ b/src/test/java/de/unistuttgart/finitequizbackend/statistic/StatisticTest.java
@@ -1,5 +1,10 @@
 package de.unistuttgart.finitequizbackend.statistic;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.unistuttgart.finitequizbackend.data.*;
 import de.unistuttgart.finitequizbackend.data.mapper.QuestionMapper;
@@ -9,6 +14,8 @@ import de.unistuttgart.finitequizbackend.repositories.ConfigurationRepository;
 import de.unistuttgart.finitequizbackend.repositories.GameResultRepository;
 import de.unistuttgart.finitequizbackend.service.GameResultService;
 import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
+import java.util.*;
+import javax.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -19,14 +26,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-
-import javax.servlet.http.Cookie;
-import java.util.*;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.doNothing;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc
 @SpringBootTest
@@ -48,11 +47,13 @@ public class StatisticTest {
 
     @Autowired
     private GameResultService gameResultService;
+
     @Autowired
     private QuestionMapper questionMapper;
 
     @Autowired
     private ConfigurationRepository configurationRepository;
+
     private ObjectMapper objectMapper;
 
     private Configuration randomConfiguration;
@@ -143,7 +144,7 @@ public class StatisticTest {
         gameResult3.setPlayedTime(new Date());
         List<RoundResult> wrongAnswers3 = new ArrayList<>();
         List<RoundResult> rightAnswers3 = new ArrayList<>();
-        for (int i = 0 ; i < 2; i++) {
+        for (int i = 0; i < 2; i++) {
             rightAnswers3.add(new RoundResult(questionList.get(i), questionList.get(i).getRightAnswer()));
         }
         for (int i = 2; i < questionList.size(); i++) {
@@ -159,7 +160,7 @@ public class StatisticTest {
         gameResult4.setPlayedTime(new Date());
         List<RoundResult> wrongAnswers4 = new ArrayList<>();
         List<RoundResult> rightAnswers4 = new ArrayList<>();
-        for (int i = 0 ; i < 5; i++) {
+        for (int i = 0; i < 5; i++) {
             rightAnswers4.add(new RoundResult(questionList.get(i), questionList.get(i).getRightAnswer()));
         }
         for (int i = 5; i < questionList.size(); i++) {
@@ -174,7 +175,6 @@ public class StatisticTest {
 
         gameResultRepository.saveAll(List.of(gameResult1, gameResult2, gameResult3, gameResult4));
 
-
         objectMapper = new ObjectMapper();
         doNothing().when(jwtValidatorService).validateTokenOrThrow("testToken");
     }
@@ -182,22 +182,30 @@ public class StatisticTest {
     @Test
     public void testGetProblematicQuestions() throws Exception {
         final MvcResult result = mvc
-                .perform(get(API_URL + "/" + staticConfiguration.getId() + "/problematic-questions").cookie(cookie).contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andReturn();
+            .perform(
+                get(API_URL + "/" + staticConfiguration.getId() + "/problematic-questions")
+                    .cookie(cookie)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andReturn();
 
         final List<ProblematicQuestion> problematicQuestions = Arrays.asList(
-                objectMapper.readValue(result.getResponse().getContentAsString(), ProblematicQuestion[].class)
+            objectMapper.readValue(result.getResponse().getContentAsString(), ProblematicQuestion[].class)
         );
 
-
-
         for (int i = 0; i < problematicQuestions.size() - 1; i++) {
-            assertTrue(problematicQuestions.get(i).getWrongAnswers() >= problematicQuestions.get(i+1).getWrongAnswers());
+            assertTrue(
+                problematicQuestions.get(i).getWrongAnswers() >= problematicQuestions.get(i + 1).getWrongAnswers()
+            );
         }
 
-
-        assertFalse(problematicQuestions.stream().map(ProblematicQuestion::getQuestion).anyMatch(question -> question.equals(bestAnsweredQuestion)));
+        assertFalse(
+            problematicQuestions
+                .stream()
+                .map(ProblematicQuestion::getQuestion)
+                .anyMatch(question -> question.equals(bestAnsweredQuestion))
+        );
         assertEquals(problematicQuestion, problematicQuestions.get(0).getQuestion());
         assertSame(5, problematicQuestions.size());
     }
@@ -205,14 +213,17 @@ public class StatisticTest {
     @Test
     public void testGetTimeSpentDistribution() throws Exception {
         final MvcResult result = mvc
-                .perform(get(API_URL + "/" + staticConfiguration.getId() + "/time-spent").cookie(cookie).contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andReturn();
+            .perform(
+                get(API_URL + "/" + staticConfiguration.getId() + "/time-spent")
+                    .cookie(cookie)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andReturn();
 
         final List<TimeSpentDistribution> timeSpentDistributions = Arrays.asList(
-                objectMapper.readValue(result.getResponse().getContentAsString(), TimeSpentDistribution[].class)
+            objectMapper.readValue(result.getResponse().getContentAsString(), TimeSpentDistribution[].class)
         );
-
         // TODO: make good tests
     }
 }


### PR DESCRIPTION
Closes Gamify-IT/issues#379

Added statistic endpoint to get top 5 most wrong answered questions and a statistic returning the distribution of spent time of game results.

TODO: frontend needs to send time in seconds of spent time in the minigame