### PR TITLE
clone Configuration

### DIFF
--- a/.github/workflows/deploy-docker-image-on-release.yml
+++ b/.github/workflows/deploy-docker-image-on-release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "main"
-      - "maintenance/clone-config"
     tags:
       - "v*"
   pull_request:

--- a/.github/workflows/deploy-docker-image-on-release.yml
+++ b/.github/workflows/deploy-docker-image-on-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+      - "maintenance/clone-config"
     tags:
       - "v*"
   pull_request:

--- a/src/main/java/de/unistuttgart/finitequizbackend/controller/ConfigController.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/controller/ConfigController.java
@@ -142,4 +142,12 @@ public class ConfigController {
         log.debug("get configuration {}", id);
         return configurationMapper.configurationToConfigurationDTO(configService.getConfiguration(id)).getQuestions();
     }
+
+    @PostMapping("/{id}/clone")
+    @ResponseStatus(HttpStatus.CREATED)
+    public UUID cloneConfiguration(@CookieValue("access_token") final String accessToken, @PathVariable final UUID id) {
+        jwtValidatorService.validateTokenOrThrow(accessToken);
+        jwtValidatorService.hasRolesOrThrow(accessToken, List.of("lecturer"));
+        return configService.cloneConfiguration(id);
+    }
 }

--- a/src/main/java/de/unistuttgart/finitequizbackend/data/Configuration.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/data/Configuration.java
@@ -56,15 +56,9 @@ public class Configuration {
     }
 
     @Override
-    public Object clone() {
-        Configuration config;
-        try {
-            config = (Configuration) super.clone();
-        } catch (CloneNotSupportedException e) {
-            config = new Configuration(this.getQuestions());
-        }
-        config.questions =
-                this.questions.stream().map(question -> question = (Question) question.clone()).collect(Collectors.toSet());
-        return config;
+    public Configuration clone() {
+        return new Configuration(
+            this.questions.stream().map(question -> question = question.clone()).collect(Collectors.toSet())
+        );
     }
 }

--- a/src/main/java/de/unistuttgart/finitequizbackend/data/Configuration.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/data/Configuration.java
@@ -58,7 +58,7 @@ public class Configuration {
     @Override
     public Configuration clone() {
         return new Configuration(
-            this.questions.stream().map(question -> question = question.clone()).collect(Collectors.toSet())
+            this.questions.stream().map(Question::clone).collect(Collectors.toSet())
         );
     }
 }

--- a/src/main/java/de/unistuttgart/finitequizbackend/data/Configuration.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/data/Configuration.java
@@ -2,6 +2,7 @@ package de.unistuttgart.finitequizbackend.data;
 
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import javax.persistence.*;
 import javax.validation.Valid;
 import lombok.AccessLevel;
@@ -52,5 +53,18 @@ public class Configuration {
      */
     public void removeQuestion(final Question question) {
         this.questions.remove(question);
+    }
+
+    @Override
+    public Object clone() {
+        Configuration config;
+        try {
+            config = (Configuration) super.clone();
+        } catch (CloneNotSupportedException e) {
+            config = new Configuration(this.getQuestions());
+        }
+        config.questions =
+                this.questions.stream().map(question -> question = (Question) question.clone()).collect(Collectors.toSet());
+        return config;
     }
 }

--- a/src/main/java/de/unistuttgart/finitequizbackend/data/Question.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/data/Question.java
@@ -1,5 +1,6 @@
 package de.unistuttgart.finitequizbackend.data;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import javax.persistence.ElementCollection;
@@ -55,5 +56,15 @@ public class Question {
         this.text = text;
         this.rightAnswer = rightAnswer;
         this.wrongAnswers = wrongAnswers;
+    }
+
+    @Override
+    public Object clone() {
+        try {
+            return super.clone();
+        } catch (CloneNotSupportedException e) {
+            return new Question(this.text, this.rightAnswer, new HashSet<>(this.wrongAnswers) {
+            });
+        }
     }
 }

--- a/src/main/java/de/unistuttgart/finitequizbackend/data/Question.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/data/Question.java
@@ -59,12 +59,7 @@ public class Question {
     }
 
     @Override
-    public Object clone() {
-        try {
-            return super.clone();
-        } catch (CloneNotSupportedException e) {
-            return new Question(this.text, this.rightAnswer, new HashSet<>(this.wrongAnswers) {
-            });
-        }
+    public Question clone() {
+        return new Question(this.text, this.rightAnswer, new HashSet<>(this.wrongAnswers) {});
     }
 }

--- a/src/main/java/de/unistuttgart/finitequizbackend/data/Question.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/data/Question.java
@@ -60,6 +60,6 @@ public class Question {
 
     @Override
     public Question clone() {
-        return new Question(this.text, this.rightAnswer, new HashSet<>(this.wrongAnswers) {});
+        return new Question(this.text, this.rightAnswer, new HashSet<>(this.wrongAnswers));
     }
 }

--- a/src/main/java/de/unistuttgart/finitequizbackend/service/ConfigService.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/service/ConfigService.java
@@ -8,8 +8,8 @@ import de.unistuttgart.finitequizbackend.data.mapper.ConfigurationMapper;
 import de.unistuttgart.finitequizbackend.data.mapper.QuestionMapper;
 import de.unistuttgart.finitequizbackend.repositories.ConfigurationRepository;
 import de.unistuttgart.finitequizbackend.repositories.QuestionRepository;
-import java.util.Optional;
-import java.util.UUID;
+
+import java.util.*;
 import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -189,6 +189,23 @@ public class ConfigService {
         question.setId(questionId);
         final Question savedQuestion = questionRepository.save(question);
         return questionMapper.questionToQuestionDTO(savedQuestion);
+    }
+
+    /**
+     * Clones the configuration with the given id
+     *
+     * @param id the id of the configuration to be cloned
+     * @return the new id of the cloned configuration
+     */
+    public UUID cloneConfiguration(final UUID id) {
+        Configuration config = configurationRepository.findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, String.format("Configuration with id %s not found", id)));
+        final Configuration cloneConfig = new Configuration(new HashSet<>());
+        config.getQuestions().forEach(question -> {
+            Set<String> wrongAnswers = new HashSet<>(question.getWrongAnswers());
+            cloneConfig.addQuestion(new Question(question.getText(), question.getRightAnswer(), wrongAnswers));
+        });
+        Configuration idConfig = configurationRepository.save(cloneConfig);
+        return idConfig.getId();
     }
 
     /**

--- a/src/main/java/de/unistuttgart/finitequizbackend/service/ConfigService.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/service/ConfigService.java
@@ -8,7 +8,6 @@ import de.unistuttgart.finitequizbackend.data.mapper.ConfigurationMapper;
 import de.unistuttgart.finitequizbackend.data.mapper.QuestionMapper;
 import de.unistuttgart.finitequizbackend.repositories.ConfigurationRepository;
 import de.unistuttgart.finitequizbackend.repositories.QuestionRepository;
-
 import java.util.*;
 import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
@@ -198,8 +197,15 @@ public class ConfigService {
      * @return the new id of the cloned configuration
      */
     public UUID cloneConfiguration(final UUID id) {
-        Configuration config = configurationRepository.findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, String.format("Configuration with id %s not found", id)));
-        Configuration cloneConfig = (Configuration) config.clone();
+        Configuration config = configurationRepository
+            .findById(id)
+            .orElseThrow(() ->
+                new ResponseStatusException(
+                    HttpStatus.NOT_FOUND,
+                    String.format("Configuration with id %s not found", id)
+                )
+            );
+        Configuration cloneConfig = config.clone();
         cloneConfig = configurationRepository.save(cloneConfig);
         return cloneConfig.getId();
     }

--- a/src/main/java/de/unistuttgart/finitequizbackend/service/ConfigService.java
+++ b/src/main/java/de/unistuttgart/finitequizbackend/service/ConfigService.java
@@ -199,13 +199,9 @@ public class ConfigService {
      */
     public UUID cloneConfiguration(final UUID id) {
         Configuration config = configurationRepository.findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, String.format("Configuration with id %s not found", id)));
-        final Configuration cloneConfig = new Configuration(new HashSet<>());
-        config.getQuestions().forEach(question -> {
-            Set<String> wrongAnswers = new HashSet<>(question.getWrongAnswers());
-            cloneConfig.addQuestion(new Question(question.getText(), question.getRightAnswer(), wrongAnswers));
-        });
-        Configuration idConfig = configurationRepository.save(cloneConfig);
-        return idConfig.getId();
+        Configuration cloneConfig = (Configuration) config.clone();
+        cloneConfig = configurationRepository.save(cloneConfig);
+        return cloneConfig.getId();
     }
 
     /**

--- a/src/test/java/de/unistuttgart/finitequizbackend/ConfigControllerTest.java
+++ b/src/test/java/de/unistuttgart/finitequizbackend/ConfigControllerTest.java
@@ -280,17 +280,35 @@ class ConfigControllerTest {
     @Test
     void testCloneConfiguration() throws Exception {
         final MvcResult result = mvc
-                .perform(post(API_URL + "/" + initialConfig.getId() + "/clone").cookie(cookie).contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isCreated())
-                .andReturn();
+            .perform(
+                post(API_URL + "/" + initialConfig.getId() + "/clone")
+                    .cookie(cookie)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isCreated())
+            .andReturn();
         final String content = result.getResponse().getContentAsString();
-        final UUID clonedId = objectMapper.readValue(content, UUID.class);
-        assertNotEquals(initialConfig.getId(), clonedId);
+        final UUID cloneId = objectMapper.readValue(content, UUID.class);
+        assertNotEquals(initialConfig.getId(), cloneId);
 
-        final Configuration cloneConfig = configurationRepository.findById(clonedId).get();
-        cloneConfig.getQuestions().forEach(question -> initialConfig.getQuestions().forEach(initialQuestion -> {
-            assertNotEquals(question.getId(), initialQuestion.getId());
-        }));
+        assertTrue(configurationRepository.findById(cloneId).isPresent());
+
+        final Configuration cloneConfig = configurationRepository.findById(cloneId).get();
+        initialConfig
+            .getQuestions()
+            .forEach(question -> {
+                // test if questions are deep-copied
+                cloneConfig
+                    .getQuestions()
+                    .forEach(cloneQuestion -> assertNotEquals(question.getId(), cloneQuestion.getId()));
+                // test if questions are still present
+                assertTrue(
+                    cloneConfig
+                        .getQuestions()
+                        .stream()
+                        .anyMatch(cloneQuestion -> question.getText().equals(cloneQuestion.getText()))
+                );
+            });
         assertNotEquals(cloneConfig, initialConfig);
     }
 }

--- a/src/test/java/de/unistuttgart/finitequizbackend/ConfigControllerTest.java
+++ b/src/test/java/de/unistuttgart/finitequizbackend/ConfigControllerTest.java
@@ -288,6 +288,9 @@ class ConfigControllerTest {
         assertNotEquals(initialConfig.getId(), clonedId);
 
         final Configuration cloneConfig = configurationRepository.findById(clonedId).get();
+        cloneConfig.getQuestions().forEach(question -> initialConfig.getQuestions().forEach(initialQuestion -> {
+            assertNotEquals(question.getId(), initialQuestion.getId());
+        }));
         assertNotEquals(cloneConfig, initialConfig);
     }
 }

--- a/src/test/java/de/unistuttgart/finitequizbackend/ConfigControllerTest.java
+++ b/src/test/java/de/unistuttgart/finitequizbackend/ConfigControllerTest.java
@@ -276,4 +276,18 @@ class ConfigControllerTest {
         assertEquals(newText, updatedQuestionResultDTO.getText());
         assertEquals(newText, questionRepository.findById(updatedQuestion.getId()).get().getText());
     }
+
+    @Test
+    void testCloneConfiguration() throws Exception {
+        final MvcResult result = mvc
+                .perform(post(API_URL + "/" + initialConfig.getId() + "/clone").cookie(cookie).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andReturn();
+        final String content = result.getResponse().getContentAsString();
+        final UUID clonedId = objectMapper.readValue(content, UUID.class);
+        assertNotEquals(initialConfig.getId(), clonedId);
+
+        final Configuration cloneConfig = configurationRepository.findById(clonedId).get();
+        assertNotEquals(cloneConfig, initialConfig);
+    }
 }


### PR DESCRIPTION
Part of https://github.com/Gamify-IT/issues/issues/387

Adds the option to clone a configuration.

This backend is the same as the towercrush- and chickenshock-backend.

To test use the description in the overworld-backend pull request.